### PR TITLE
Use Windows Server 2022 for GitHub actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
           - ubuntu-latest
           - macos-13
           - macos-latest
-          - windows-2019
+          - windows-2022
           - windows-latest
           - windows-11-arm
           - alpine


### PR DESCRIPTION
Since Windows Server 2019 is deprecated and will be removed.

Windows Server 19 readme:
https://github.com/actions/runner-images/blob/main/images/windows/Windows2019-Readme.md

Windows Server 22 readme:
https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md

It uses OS:
OS Version: 10.0.20348 Build 3695
Image Version: 20250602.1.0

While Windows Server 19 used:
OS Version: 10.0.17763 Build 7322
Image Version: 20250602.2.0
