### PR TITLE
Move Linux CI agents to Ubuntu 24.04

### DIFF
--- a/.teamcity/src/main/kotlin/Platform.kt
+++ b/.teamcity/src/main/kotlin/Platform.kt
@@ -17,8 +17,8 @@
 import jetbrains.buildServer.configs.kotlin.Requirements
 
 enum class Agent(val os: Os, val architecture: Architecture, val container: String? = null, val optional: Boolean = false) {
-    AlpineLinuxAmd64(os = Os.Ubuntu22, architecture = Architecture.Amd64, container = "eclipse-temurin:17-alpine"),
-    UbuntuAmd64(os = Os.Ubuntu16, architecture = Architecture.Amd64),
+    AlpineLinuxAmd64(os = Os.Ubuntu24, architecture = Architecture.Amd64, container = "eclipse-temurin:17-alpine"),
+    UbuntuAmd64(os = Os.Ubuntu24, architecture = Architecture.Amd64),
     UbuntuAarch64(os = Os.Ubuntu24, architecture = Architecture.Aarch64),
     CentOsAmd64(os = Os.CentOs, architecture = Architecture.Amd64),
     WindowsAmd64(os = Os.Windows, architecture = Architecture.Amd64),
@@ -29,10 +29,6 @@ enum class Agent(val os: Os, val architecture: Architecture, val container: Stri
 interface Os {
     fun addAgentRequirements(requirements: Requirements)
     val osType: String
-
-    object Ubuntu16 : Ubuntu(16)
-
-    object Ubuntu22 : Ubuntu(22) // Ubuntu 22.04 LTS + Docker
 
     object Ubuntu24 : Ubuntu(24)
 


### PR DESCRIPTION
Part of migrating the native-platform / gradle-fileevents EC2 build-agent AMIs into the
**gradle-bt-ci** AWS account (us-west-2). There, the Ubuntu agents standardize on **24.04** —
Ubuntu 16.04/18.04 AMIs are no longer published by Canonical, and 22.04 is dropped.

## Change
- `UbuntuAmd64`: `Os.Ubuntu16` → `Os.Ubuntu24`
- `AlpineLinuxAmd64`: host `Os.Ubuntu22` → `Os.Ubuntu24` (build runs inside the
  `eclipse-temurin:17-alpine` container, so the host OS version is irrelevant)
- Remove the now-unused `Os.Ubuntu16` / `Os.Ubuntu22`

## Why this is safe
fileevents' release build (`Build`/`Publish`) runs on **macOS**; the Linux agents only run
`externalTest`. So this changes only what we *test on*, not any shipped binary — no glibc-floor
impact. (That is **not** true for native-platform, whose Ubuntu agents build released libraries;
that repo's change is handled separately with a glibc-preserving container build.)

## Cutover dependency
Depends on the gradle-bt-ci us-west-2 cloud profile serving the new Ubuntu 24 agents
(AMIs baked in dev-infrastructure#3178). **Do not merge** until that profile is live, or
`UbuntuAmd64`/`AlpineLinuxAmd64` tests will have no matching agent.