### PR TITLE
Disable file events on old Windows versions

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -32,6 +32,7 @@ pub fn build(b: *std.Build) void {
 
     const cpp_args = if (target.result.os.tag == .windows)
         base_cpp_args ++ &[_][]const u8{
+            // Keep in sync with FileEvents.isWindowsVersionSupported()
             "-DNTDDI_VERSION=NTDDI_WIN10_RS3",
             // Need this to actually get our functions in the export table
             "-DJNIEXPORT=__declspec(dllexport)",

--- a/src/main/java/org/gradle/fileevents/FileEvents.java
+++ b/src/main/java/org/gradle/fileevents/FileEvents.java
@@ -47,9 +47,11 @@ public class FileEvents {
             }
             Platform platform = Platform.current();
             String platformName = getPlatformName(platform);
+            String libraryName = determineLibraryName(platform);
+            checkPlatformVersionIsSupported(platform);
             try {
                 NativeLibraryLocator loader = new NativeLibraryLocator(extractDir, FileEventsVersion.VERSION);
-                File library = loader.find(new LibraryDef(determineLibraryName(platform), platformName));
+                File library = loader.find(new LibraryDef(libraryName, platformName));
                 if (library == null) {
                     throw new NativeIntegrationUnavailableException(String.format("Native file events integration is not available for %s.", platform));
                 }
@@ -94,6 +96,44 @@ public class FileEvents {
                 return "aarch64-macos";
             default:
                 throw new NativeIntegrationUnavailableException(String.format("Native file events integration is not available for %s.", platform));
+        }
+    }
+
+    private static void checkPlatformVersionIsSupported(Platform platform) {
+        if (!platform.isWindows()) {
+            return;
+        }
+        String osName = System.getProperty("os.name", "");
+        String osVersion = System.getProperty("os.version", "");
+        if (!isWindowsVersionSupported(osName, osVersion)) {
+            throw new NativeIntegrationUnavailableException(
+                String.format("Native file events integration is not available for %s %s. It requires at least Windows 10 or Windows Server 2019.", osName, osVersion)
+            );
+        }
+    }
+
+    /**
+     * The native library targets the Windows 10 1709 API ({@code NTDDI_VERSION} in {@code build.zig})
+     * and fails to load on older versions. Windows Server 2016 reports version 10.0 but is based on
+     * the older 1607 build, so it is excluded by name.
+     * See <a href="https://github.com/gradle/gradle/issues/31939">gradle/gradle#31939</a>.
+     */
+    static boolean isWindowsVersionSupported(String osName, String osVersion) {
+        if (osName.contains("Server 2016")) {
+            return false;
+        }
+        int majorVersion = parseMajorVersion(osVersion);
+        return majorVersion < 0 || majorVersion >= 10;
+    }
+
+    private static int parseMajorVersion(String version) {
+        int end = version.indexOf('.');
+        String major = end == -1 ? version : version.substring(0, end);
+        try {
+            return Integer.parseInt(major.trim());
+        } catch (NumberFormatException e) {
+            // Unknown format, assume it's a recent version
+            return -1;
         }
     }
 

--- a/src/test/groovy/org/gradle/fileevents/WindowsVersionSupportTest.groovy
+++ b/src/test/groovy/org/gradle/fileevents/WindowsVersionSupportTest.groovy
@@ -1,0 +1,29 @@
+package org.gradle.fileevents
+
+import spock.lang.Specification
+
+class WindowsVersionSupportTest extends Specification {
+    def "file events are #description on #osName #osVersion"() {
+        expect:
+        FileEvents.isWindowsVersionSupported(osName, osVersion) == supported
+
+        where:
+        osName                   | osVersion | supported
+        "Windows Vista"          | "6.0"     | false
+        "Windows 7"              | "6.1"     | false
+        "Windows 8"              | "6.2"     | false
+        "Windows 8.1"            | "6.3"     | false
+        "Windows Server 2008 R2" | "6.1"     | false
+        "Windows Server 2012 R2" | "6.3"     | false
+        "Windows Server 2016"    | "10.0"    | false
+        "Windows Server 2019"    | "10.0"    | true
+        "Windows Server 2022"    | "10.0"    | true
+        "Windows 10"             | "10.0"    | true
+        "Windows 11"             | "10.0"    | true
+        "Windows 11"             | "11"      | true
+        // Unrecognized version formats should not disable file events
+        "Windows NT (unknown)"   | ""        | true
+
+        description = supported ? "supported" : "not supported"
+    }
+}


### PR DESCRIPTION
The native library targets the Windows 10 1709 API and fails to load on older versions such as Windows Server 2016. See gradle/gradle#31939.